### PR TITLE
Add Rake task to verify linting is working

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -9,4 +9,13 @@ end
 
 require "standard/rake"
 
+desc "Verify linting works in example project"
+task :lint_test do
+  Rake::Task["install"].execute
+  output = `cd example; bundle exec standardrb`
+  unless output.include?("type_check_me.rb:1:1: Sorbet/FalseSigil: Invalid Sorbet sigil `banana`.")
+    fail "Expected linting violation not detected."
+  end
+end
+
 task default: %i[test standard:fix]

--- a/Rakefile
+++ b/Rakefile
@@ -14,7 +14,7 @@ task :lint_test do
   Rake::Task["install"].execute
   output = `cd example; bundle exec standardrb`
   unless output.include?("type_check_me.rb:1:1: Sorbet/FalseSigil: Invalid Sorbet sigil `banana`.")
-    fail "Expected linting violation not detected."
+    fail "Expected linting violation not detected. Ensure that the example project properly detects Sorbet linting violations."
   end
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -18,4 +18,4 @@ task :lint_test do
   end
 end
 
-task default: %i[test standard:fix]
+task default: %i[test standard:fix lint_test]

--- a/example/type_check_me.rb
+++ b/example/type_check_me.rb
@@ -1,3 +1,3 @@
-# typed: true
+# typed: banana
 
 puts "Please type check me"

--- a/example/type_check_me.rb
+++ b/example/type_check_me.rb
@@ -1,3 +1,3 @@
-# typed: banana
+# typed: true
 
 puts "Please type check me"

--- a/example/type_check_me.rb
+++ b/example/type_check_me.rb
@@ -1,1 +1,3 @@
+# typed: banana
+
 puts "Please type check me"


### PR DESCRIPTION
Closes #1 

Adds a Rake task to verify the linting works in the example project.

@searls I went back and forth on adding this to the default Rake task. On the plus side, I didn't need to alter the GH Action workflow to add this check, and I like locally being able to run exactly what GH Actions will run. On the negative side, we need to install the gem from the source for this work properly, which takes a non-trivial amount of time (~10 seconds), and I don't love how that breaks flow if you're using the default task for rapid local development. Thoughts?