### PR TITLE
Update `rubocop-sorbet` to version 0.9.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     standard-sorbet (0.0.2)
       lint_roller (~> 1.1)
-      rubocop-sorbet (~> 0.7.0)
+      rubocop-sorbet (~> 0.9.0)
 
 GEM
   remote: https://rubygems.org/
@@ -43,8 +43,9 @@ GEM
     rubocop-performance (1.21.1)
       rubocop (>= 1.48.1, < 2.0)
       rubocop-ast (>= 1.31.1, < 2.0)
-    rubocop-sorbet (0.7.0)
-      rubocop (>= 0.90.0)
+    rubocop-sorbet (0.9.0)
+      lint_roller (~> 1.1)
+      rubocop (>= 1)
     ruby-progressbar (1.13.0)
     simplecov (0.22.0)
       docile (~> 1.1)

--- a/config/base.yml
+++ b/config/base.yml
@@ -1,3 +1,6 @@
+Sorbet/Refinement:
+  Enabled: pending
+
 Sorbet/AllowIncompatibleOverride:
   Enabled: true
 
@@ -37,7 +40,25 @@ Sorbet/ForbidRBIOutsideOfAllowedPaths:
 Sorbet/ForbidIncludeConstLiteral:
   Enabled: false
 
+Sorbet/ForbidTypeAliasedShapes:
+  Enabled: false
+
+Sorbet/ForbidSig:
+  Enabled: false
+
+Sorbet/ForbidSigWithRuntime:
+  Enabled: false
+
+Sorbet/ForbidSigWithoutRuntime:
+  Enabled: false
+
 Sorbet/ForbidSuperclassConstLiteral:
+  Enabled: false
+
+Sorbet/ForbidTEnum:
+  Enabled: false
+
+Sorbet/ForbidTStruct:
   Enabled: false
 
 Sorbet/ForbidTUnsafe:
@@ -55,11 +76,17 @@ Sorbet/HasSigil:
 Sorbet/IgnoreSigil:
   Enabled: false
 
+Sorbet/ImplicitConversionMethod:
+  Enabled: false
+
 Sorbet/KeywordArgumentOrdering:
   Enabled: true
 
-Sorbet/OneAncestorPerLine:
-  Enabled: false
+Sorbet/ObsoleteStrictMemoization:
+  Enabled: true
+
+Sorbet/BuggyObsoleteStrictMemoization:
+  Enabled: true
 
 Sorbet/RedundantExtendTSig:
   Enabled: false
@@ -83,4 +110,13 @@ Sorbet/TypeAliasName:
   Enabled: true
 
 Sorbet/ValidSigil:
+  Enabled: true
+
+Sorbet/VoidCheckedTests:
+  Enabled: true
+
+Sorbet/MultipleTEnumValues:
+  Enabled: true
+
+Sorbet/ForbidComparableTEnum:
   Enabled: true

--- a/standard-sorbet.gemspec
+++ b/standard-sorbet.gemspec
@@ -29,5 +29,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "lint_roller", "~> 1.1"
-  spec.add_dependency "rubocop-sorbet", "~> 0.7.0"
+  spec.add_dependency "rubocop-sorbet", "~> 0.9.0"
 end


### PR DESCRIPTION
Update `rubocop-sorbet` version to 0.9.0 to resolve warnings that are currently displayed when running `bundle exec standardrb`. For example:

```
warning: Inheriting from `RuboCop::Cop::Cop` is deprecated. Use `RuboCop::Cop::Base` instead.
warning: `Cop.registry` is deprecated. Use `Registry.global` instead.
```

This should resolve #17 where you can find more details on the motivation for this PR.